### PR TITLE
Adds the declaration of the computed_size variable (with the default …

### DIFF
--- a/recycleview.py
+++ b/recycleview.py
@@ -226,6 +226,7 @@ class LinearRecycleLayoutManager(RecycleLayoutManager):
     # internal
     computed_sizes = []
     computed_positions = []
+    computed_size = 0
 
     def can_scroll_horizontally(self):
         return self.orientation == "horizontal"


### PR DESCRIPTION
I wanted to play with the LinearRecycleLayoutManager. I noticed I can not explicitly call the method compute_positions_and_sizes() of the superclass, because the instance variable computed_size is defined first in this method. Adding the declaration of this variable with a default value to the beginning of the class fixes this.
