### PR TITLE
Rework recycleview for consistnecy and efficiency

### DIFF
--- a/examples/contacts/main.py
+++ b/examples/contacts/main.py
@@ -1,4 +1,4 @@
-from recycleview import RecycleView
+from kivy.garden.recycleview import RecycleView
 from kivy.base import runTouchApp
 from kivy.lang import Builder
 from kivy.app import App
@@ -72,7 +72,7 @@ class RecycleViewApp(App):
         contacts = []
         names = ["Robert", "George", "Joseph", "Donald", "Mark", "Anthony", "Gary"]
         medias = [
-            "http://pbs.twimg.com/profile_images/3312895495/8e39061bdad2b5d18dc8a9be63a2f50a_normal.png",
+            "http://www.geglobalresearch.com/media/Alhart-Todd-45x45.jpg",
             "http://www.geglobalresearch.com/media/Alhart-Todd-45x45.jpg",
         ]
         for x in range(1000):

--- a/examples/wallimage/main.py
+++ b/examples/wallimage/main.py
@@ -1,6 +1,6 @@
 from kivy.app import App
 from kivy.properties import ListProperty
-from recycleview import RecycleView
+from kivy.garden.recycleview import RecycleView
 from kivy.lang import Builder
 from os.path import dirname, join
 from glob import glob

--- a/examples/wallimage/wallimage.kv
+++ b/examples/wallimage/wallimage.kv
@@ -1,5 +1,5 @@
 #:kivy 1.9
-#:import LinearRecycleLayoutManager recycleview.LinearRecycleLayoutManager
+#:import LinearRecycleLayoutManager kivy.garden.recycleview.LinearRecycleLayoutManager
 
 <WallImage@Image>:
 

--- a/recycleview.py
+++ b/recycleview.py
@@ -122,7 +122,11 @@ class RecycleAdapter(EventDispatcher):
 
     def make_view_dirty(self, view, index):
         """(internal) Used to flag the view as dirty, ready to be used for
-        others.
+        others. A dirty view can be reused by just changing the pos/size.
+        So it's assumed that while in dirty view that index stays in sync
+        with the data. If we want to still cache the view but not keep that
+        assumption, use a negative index; it'll keep the view for reuse but
+        does not assume the view is tied to data.
         """
         self.dirty_views[view.__class__][index] = view
 
@@ -136,7 +140,7 @@ class RecycleAdapter(EventDispatcher):
         make_view_dirty = self.make_view_dirty
 
         for index, view in views.items():
-            make_view_dirty(view, index)
+            make_view_dirty(view, -index)
         self.views = {}
 
     def get_views(self, i_start, i_end):

--- a/recycleview.py
+++ b/recycleview.py
@@ -511,7 +511,7 @@ class RecycleView(ScrollView):
     def observable_dict(self):
         '''It's specific to the adapter present when called.
         '''
-        return self.adapter.observable_dict()
+        return self.adapter.observable_dict
 
     def _handle_ask_data_refresh(self, *largs, **kwargs):
         self._refresh_flags[kwargs['extent']] = True

--- a/recycleview.py
+++ b/recycleview.py
@@ -402,16 +402,16 @@ class RecycleView(ScrollView):
     '''
 
     def __init__(self, **kwargs):
-        super(RecycleView, self).__init__(**kwargs)
         self._refresh_flags = dict(self._refresh_flags)
         self._refresh_trigger = Clock.create_trigger(self.refresh_views, -1)
 
-        if self._container is None:
-            self.container = RecycleViewLayout(size_hint=(None, None))
         if self._layout_manager is None:
             self.layout_manager = LinearRecycleLayoutManager()
         if self._adapter is None:
             self.adapter = RecycleAdapter()
+        super(RecycleView, self).__init__(**kwargs)
+        if self._container is None:
+            self.container = RecycleViewLayout(size_hint=(None, None))
 
         fbind = self.fbind
         fbind('size', self.trigger_refresh, data_size=True)

--- a/recycleview.py
+++ b/recycleview.py
@@ -29,7 +29,7 @@ from collections import defaultdict
 from functools import partial
 from distutils.version import LooseVersion
 
-_kivy_has_last_op = LooseVersion(kivy.__version__) >= LooseVersion('1.9.1')
+_kivy_1_9_1 = LooseVersion(kivy.__version__) >= LooseVersion('1.9.1')
 
 _cached_views = defaultdict(list)
 _cache_count = 0
@@ -221,7 +221,7 @@ class RecycleAdapter(EventDispatcher):
         # remove all the widgets. Otherwise if only append or extend, we don't
         # have to make everything dirty because the current items are good, we
         # just need to re-layout so pass on that info
-        if not _kivy_has_last_op:
+        if not _kivy_1_9_1:
             self.dispatch('on_data_changed', extent='data')
             return
 
@@ -453,7 +453,7 @@ class RecycleView(ScrollView):
         if self._container is None:
             self.container = RecycleViewLayout(size_hint=(None, None))
 
-        fbind = self.fbind
+        fbind = self.fbind if _kivy_1_9_1 else self.fast_bind
         fbind('size', self.ask_refresh_from_data, extent='data_size')
         fbind('scroll_x', self.ask_refresh_viewport)
         fbind('scroll_y', self.ask_refresh_viewport)
@@ -526,7 +526,8 @@ class RecycleView(ScrollView):
             return
         if adapter is not None:
             adapter.detach_recycleview()
-            adapter.funbind('on_data_changed', self._handle_ask_data_refresh)
+            funbind = adapter.funbind if _kivy_1_9_1 else adapter.fast_unbind
+            funbind('on_data_changed', self._handle_ask_data_refresh)
 
         if value is None:
             self._adapter = adapter = RecycleAdapter()
@@ -538,7 +539,8 @@ class RecycleView(ScrollView):
             self._adapter = adapter = value
 
         adapter.attach_recycleview(self)
-        adapter.fbind('on_data_changed', self._handle_ask_data_refresh)
+        fbind = adapter.fbind if _kivy_1_9_1 else adapter.fast_bind
+        fbind('on_data_changed', self._handle_ask_data_refresh)
         self.ask_refresh_from_data()
         return True
 

--- a/recycleview.py
+++ b/recycleview.py
@@ -434,9 +434,12 @@ class RecycleView(ScrollView):
 
         if update:
             lm.compute_positions_and_sizes(flags['data_add'])
-            lm.compute_visible_views()
-        elif flags['view']:
-            lm.compute_visible_views()
+
+        if update or flags['view']:
+            if self.data:
+                lm.compute_visible_views()
+            else:
+                self.adapter.invalidate()
 
         flags['recycleview'] = flags['data'] = flags['data_size'] = \
             flags['data_add'] = flags['view'] = False

--- a/recycleview.py
+++ b/recycleview.py
@@ -20,7 +20,8 @@ from kivy.compat import string_types
 from kivy.uix.widget import Widget
 from kivy.uix.scrollview import ScrollView
 from kivy.properties import NumericProperty, AliasProperty, StringProperty, \
-    ObjectProperty, ListProperty, OptionProperty, BooleanProperty
+    ObjectProperty, ListProperty, OptionProperty, BooleanProperty, \
+    ObservableDict
 from kivy.event import EventDispatcher
 from kivy.factory import Factory
 from kivy.clock import Clock
@@ -61,6 +62,10 @@ class RecycleAdapter(EventDispatcher):
         """Return the data entry at `index`
         """
         return self.data[index]
+
+    @property
+    def observable_dict(self):
+        return partial(ObservableDict, self.__class__.data, self)
 
     def attach_recycleview(self, rv):
         self.recycleview = rv
@@ -467,11 +472,21 @@ class RecycleView(ScrollView):
         flags[extent] = True
         self._refresh_trigger()
 
+    def ask_refresh_viewport(self, *largs):
+        self._refresh_flags['all'] = True
+        self._refresh_trigger()
+
     def refresh_view_layout(self, index, view):
         self.layout_manager.refresh_view_layout(index, view)
 
     def get_views(self, i_start, i_end):
         return self.adapter.get_views(i_start, i_end)
+
+    @property
+    def observable_dict(self):
+        '''It's specific to the adapter present when called.
+        '''
+        return self.adapter.observable_dict()
 
     def _get_adapter(self):
         return self._adapter


### PR DESCRIPTION
This PR basically reworks recycleview to make it more consistent and performant. I reworked it like a piece of dough, so it has many changes throughout and hopefully did not go down the road of undesired changes. I do think this makes it a lot more consistent and cleans up some remaining issues.

Here are some of the bigger changes:
- I made RecycleView a ScrollView because I don't see the reason for wrapping it. The scrollview props should be available to the user, e.g. scroll pos, effects, etc. Otherwise we'd have to wrap access to them. Also, e.g. the view manager already assumes that there's a scrollview in the stack by setting its props etc. So why not make RecycleView a scrollview directly?
- Instead of making container hardcoded, I made it a property so it can be changed. Not sure this is needed, but it makes it more robust.
- I removed the default_adapter/layout manager and made them alias props which cleans up the on_adapter etc methods. Also, similar to default adapter/manager, if it is set to None, we create a default adaper/manager.
- Really though, I think we should not do this but leave it to None at the user's peril, except for initially making sure it's not None. But if the user sets it to None, they probably know what they are doing.
- In order to ensure that the least amount of updates is done to the views I added `_refresh_flags` to `RecycleView`. Setting these flags depending on what changed requiring the update we can do this. Here's the flags and it's doc in that class:

``` py
_refresh_flags = {
        'recycleview': True, 'data': True, 'data_size': True,
        'data_add': True, 'view': True
    }
    '''These flags indicate how much the view is out of sync and needs to
    be synchronized with the data. The goal is that the minimum amount
    of synchronization should be done. The flags are ordered such that for
    each flag, all the ops required for the proceeding flags are reduced by
    some known info about the change causing the refresh.

    Meaning of the flags:
    -recycleview: Initial setup of the recycleview itself. E.g. do_scroll_x.
        Updates everything.
    -data: Signal that the data changed and all the attributes/size/pos
        may have changed so they need to be recomputed and all attrs
        re-applied. This
    -data_size: Signal that the pos/size attrs of the data may have changed,
        new data may have been added, and or old data was removed. However,
        no existing data attrs was changed, beyond the size/pos values. This
        means that we don't need to re-apply the data attrs, other than
        size/pos for existing data insatances because they did not change.
        Added data will get new class instances and will have their values
        applied.
    -data_add: Similar to `data_size`, except that data, if added, was added
        at the end. This will allow further possible optimizations, but may
        be implemented as `data_size`.
    -view: The items visible changed, so we have to move our viewport.
        Other than viewport, nothing is recalculated.
    '''
```
- **Note**: https://github.com/kivy/kivy/pull/3483 is required for this to work. That PR allows us to know the level of changes done to the data in order to reduce the updating. This in particular would be required for a `FileChooser` because as the file list is read in at every clock cycle and appended to the end of the list of processed files, we don't want to have to recompute everything. By knowing that data was only added at the end, we can just update and compute the stuff for the new files only.

My goals after this is to try to add a gridded/stack view, try to convert filechooser to use this, and add selection if possible (probably with CompoundSelectionBehavior or something based on it).
