### PR TITLE
More fixes

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -1,4 +1,4 @@
 __version__ = "0.1"
 from .recycleview import RecycleView, RecycleLayoutManager, \
-    LinearRecycleLayoutManager, RecycleAdapter, ViewBaseClass, \
+    LinearRecycleLayoutManager, RecycleAdapter, RecycleViewMixin, \
     LayoutChangeException

--- a/__init__.py
+++ b/__init__.py
@@ -1,3 +1,4 @@
 __version__ = "0.1"
 from .recycleview import RecycleView, RecycleLayoutManager, \
-    LinearRecycleLayoutManager, RecycleAdapter
+    LinearRecycleLayoutManager, RecycleAdapter, ViewBaseClass, \
+    LayoutChangeException

--- a/recycleview.py
+++ b/recycleview.py
@@ -497,13 +497,13 @@ class LinearRecycleLayoutManager(RecycleLayoutManager):
         if self.orientation == "vertical":
             h = container.height
             scroll_y = 1 - (min(1, max(recycleview.scroll_y, 0)))
-            px_start = (h - recycleview.height) * scroll_y
+            px_start = max(0, (h - recycleview.height) * scroll_y)
             px_end = px_start + recycleview.height
             viewport = 0, h - px_end, container.width, h - px_start
         else:
             w = container.width
             scroll_x = 1 - (min(1, max(recycleview.scroll_x, 0)))
-            px_start = (w - recycleview.width) * scroll_x
+            px_start = max(0, (w - recycleview.width) * scroll_x)
             px_end = px_start + recycleview.width
             viewport = w - px_end, 0, w - px_start, container.height
 
@@ -560,7 +560,7 @@ class LinearRecycleLayoutManager(RecycleLayoutManager):
     def get_view_index_at(self, pos):
         for index, c_pos in enumerate(self.computed_positions):
             if c_pos > pos:
-                return index - 1
+                return max(index - 1, 0)
         return index
 
 

--- a/recycleview.py
+++ b/recycleview.py
@@ -173,7 +173,7 @@ class RecycleAdapter(EventDispatcher):
             _view_base_cache[viewclass] = isinstance(view, ViewBaseClass)
 
         if _view_base_cache[viewclass]:
-            view.refresh_view_attrs(self.rv, item)
+            view.refresh_view_attrs(self.recycleview, item)
         else:
             for key, value in item.items():
                 setattr(view, key, value)
@@ -473,15 +473,17 @@ class LinearRecycleLayoutManager(RecycleLayoutManager):
         recycleview = self.recycleview
         container = recycleview.container
         if self.orientation == "vertical":
+            h = container.height
             scroll_y = 1 - (min(1, max(recycleview.scroll_y, 0)))
-            px_start = (container.height - recycleview.height) * scroll_y
+            px_start = (h - recycleview.height) * scroll_y
             px_end = px_start + recycleview.height
-            viewport = 0, px_start, container.width, px_end
+            viewport = 0, h - px_end, container.width, h - px_start
         else:
+            w = container.width
             scroll_x = 1 - (min(1, max(recycleview.scroll_x, 0)))
-            px_start = (container.width - recycleview.width) * scroll_x
+            px_start = (w - recycleview.width) * scroll_x
             px_end = px_start + recycleview.width
-            viewport = px_start, 0, px_end, container.height
+            viewport = w - px_end, 0, w - px_start, container.height
 
         # now calculate the view indices we must show
         at_idx = self.get_view_index_at

--- a/recycleview.py
+++ b/recycleview.py
@@ -33,7 +33,7 @@ _kivy_1_9_1 = LooseVersion(kivy.__version__) >= LooseVersion('1.9.1')
 
 _view_base_cache = {}
 '''Cache whose keys are classes and values is a boolean indicating whether the
-class inherits from :class:`ViewBaseClass`.
+class inherits from :class:`RecycleViewMixin`.
 '''
 
 _cached_views = defaultdict(list)
@@ -72,7 +72,7 @@ class RecycleViewLayout(Widget):
     pass
 
 
-class ViewBaseClass(object):
+class RecycleViewMixin(object):
     '''A optional base class for data views (:attr:`RecycleView`.viewclass).
     If a view inherits from this class, the class's functions will be called
     when the view needs to be updated due to a data change or layout update.
@@ -180,7 +180,7 @@ class RecycleAdapter(EventDispatcher):
         # work for reloading as well.
         view = viewclass(**item)
         if viewclass not in _view_base_cache:
-            _view_base_cache[viewclass] = isinstance(view, ViewBaseClass)
+            _view_base_cache[viewclass] = isinstance(view, RecycleViewMixin)
 
         if _view_base_cache[viewclass]:
             view.refresh_view_attrs(self.recycleview, item)
@@ -226,7 +226,8 @@ class RecycleAdapter(EventDispatcher):
         if stale is True:
             item = self[index]
             if viewclass not in _view_base_cache:
-                _view_base_cache[viewclass] = isinstance(view, ViewBaseClass)
+                _view_base_cache[viewclass] = isinstance(view,
+                                                         RecycleViewMixin)
 
             if _view_base_cache[viewclass]:
                 view.refresh_view_attrs(rv, item)
@@ -520,7 +521,8 @@ class LinearRecycleLayoutManager(RecycleLayoutManager):
         container = rv.container
         view.size_hint = None, None
         if view.__class__ not in _view_base_cache:
-            _view_base_cache[view.__class__] = isinstance(view, ViewBaseClass)
+            _view_base_cache[view.__class__] = isinstance(view,
+                                                          RecycleViewMixin)
 
         if self.orientation == "vertical":
             view.width = container.width


### PR DESCRIPTION
PR:
- Removed refresh_view_layout from rv because I think this should only be called by the layout manager. Externally, we can only ask for a refresh from data etc, not for a specific view. Also, currently, if the view was visible already, adapter would return it and the **lm** would call refresh_view_layout on it. But if the adapter didn't have it, it'd create it and the **adapter** would call refresh_view_layout on it, not **lm**. So I made the lm always call refresh_view_layout and removed it from adapter and rv.
-  Created optional view baseclass `RecycleViewMixin`.
-  Added a `LayoutChangeException` class that can be raised during a refresh to cause a restart in the refresh.
-  Fixed some issues with computing the current views.
-  Smaller fixes.
