### PR TITLE
Allow append on empty item list.

### DIFF
--- a/recycleview.py
+++ b/recycleview.py
@@ -443,7 +443,7 @@ class LinearRecycleLayoutManager(RecycleLayoutManager):
         key_size = self.key_size
         default_size = self.default_size
         data = recycleview.adapter.data
-        if append:
+        if append and len(self.computed_positions) > 0:
             sizes = self.computed_sizes
             pos = self.computed_positions
             n = len(sizes)


### PR DESCRIPTION
If you initialise a simple RecycleView with data = [], it will die on the first item append because computed_positions list is empty. Changing so an empty list append is processed like setting a new list.
