### PR TITLE
Add log type view scroll behaviour

### DIFF
--- a/recycleview.py
+++ b/recycleview.py
@@ -596,16 +596,17 @@ class LinearRecycleLayoutManager(RecycleLayoutManager):
         """
         recycleview = self.recycleview
         if self.orientation == "vertical":
-            k = ('height', 'scroll_y')
+            k = (1, 'scroll_y')
         else:
-            k = ('width', 'scroll_x')
+            k = (0, 'scroll_x')
 
         if not self.follow_tail or getattr(recycleview, k[1]) > 0.:
-            new_size = getattr(recycleview.container, k[0])
-            window = previous_viewport[2] - previous_viewport[1]
+            new_size = recycleview.container.size[k[0]]
+            window = previous_viewport[2][k[0]] - previous_viewport[1][k[0]]
             delta = new_size - previous_viewport[0]
-            scroll = (previous_viewport[0] - window + delta - previous_viewport[1])\
-                    / (new_size - window)
+            scroll = (previous_viewport[0] - window + delta - \
+                      previous_viewport[1][k[0]])\
+                     / (new_size - window)
             setattr(recycleview, k[1], min(1., max(0., scroll)))
 
     def compute_visible_views(self):

--- a/recycleview.py
+++ b/recycleview.py
@@ -602,11 +602,10 @@ class LinearRecycleLayoutManager(RecycleLayoutManager):
 
         if not self.follow_tail or getattr(recycleview, k[1]) > 0.:
             new_size = recycleview.container.size[k[0]]
-            window = previous_viewport[2][k[0]] - previous_viewport[1][k[0]]
+            window = previous_viewport[1][k[0]] - previous_viewport[2][k[0]]
             delta = new_size - previous_viewport[0]
-            scroll = (previous_viewport[0] - window + delta - \
-                      previous_viewport[1][k[0]])\
-                     / (new_size - window)
+            scroll = (previous_viewport[2][k[0]] + delta) / \
+                      (new_size - window)
             setattr(recycleview, k[1], min(1., max(0., scroll)))
 
     def compute_visible_views(self):

--- a/recycleview.py
+++ b/recycleview.py
@@ -600,13 +600,15 @@ class LinearRecycleLayoutManager(RecycleLayoutManager):
         else:
             k = (0, 'scroll_x')
 
-        if not self.follow_tail or getattr(recycleview, k[1]) > 0.:
+        if not self.follow_tail or previous_viewport[2][k[0]] > 0.:
             new_size = recycleview.container.size[k[0]]
             window = previous_viewport[1][k[0]] - previous_viewport[2][k[0]]
             delta = new_size - previous_viewport[0]
             scroll = (previous_viewport[2][k[0]] + delta) / \
                       (new_size - window)
             setattr(recycleview, k[1], min(1., max(0., scroll)))
+        elif self.follow_tail:
+            setattr(recycleview, k[1], 0.)
 
     def compute_visible_views(self):
         """(internal) Determine the views that need to be showed in the current


### PR DESCRIPTION
append_keep_position=True will make appends not change the relative position of the viewport. In other words, the viewport will remain static and unaltered when appending new view items to it.
follow_tail=True, when used with append_keep_position, will keep the last inserted view item visible on append if the previously last item was visible.
